### PR TITLE
cuda unit test bug fix for embedded geometry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ CUDA_LIBS =
 ifeq ($(CC), nvcc)
 	USING_NVCC = yes
 	CFLAGS = -O3 -g --forward-unknown-to-host-compiler --use_fast_math -ffast-math -MMD -MP -fPIC -DGIT_COMMIT_ID=\"$(GIT_TIP)\" -DGKYL_BUILD_DATE="${BUILD_DATE}" -DGKYL_GIT_CHANGESET="${GIT_TIP}"
-	NVCC_FLAGS = -x cu -dc -arch=sm_${CUDA_ARCH} -rdc=true --compiler-options="-fPIC"
+	NVCC_FLAGS = -x cu -dc -arch=sm_${CUDA_ARCH} -rdc=true --compiler-options="-fPIC" -Xptxas --disable-optimizer-constants
 	LDFLAGS += -arch=sm_${CUDA_ARCH} -rdc=true
 	ifdef CUDAMATH_LIBDIR
 		CUDA_LIBS = -L${CUDAMATH_LIBDIR}

--- a/moments/unit/ctest_wv_ten_moment_cu.cu
+++ b/moments/unit/ctest_wv_ten_moment_cu.cu
@@ -79,14 +79,14 @@ void ker_cu_wv_ten_moment_test(const struct gkyl_wv_eqn *eqn, int *nfail)
     double delta[10];
     for (int i=0; i<10; ++i) delta[i] = qr_local[i]-ql_local[i];
     
-    eqn->waves_func(eqn, GKYL_WV_HIGH_ORDER_FLUX, delta, ql_local, qr_local, waves_local, speeds);
+    eqn->waves_func(eqn, GKYL_WV_HIGH_ORDER_FLUX, delta, ql_local, qr_local, 1.0, 1.0, waves_local, speeds);
 
     // rotate waves back to global frame
     for (int mw=0; mw<5; ++mw)
       eqn->rotate_to_global_func(eqn, tau1[d], tau2[d], norm[d], &waves_local[mw*10], &waves[mw*10]);
 
     double apdq[10], amdq[10];
-    eqn->qfluct_func(eqn, GKYL_WV_HIGH_ORDER_FLUX, ql, qr, waves, speeds, amdq, apdq);
+    eqn->qfluct_func(eqn, GKYL_WV_HIGH_ORDER_FLUX, ql, qr, 1.0, 1.0, waves, speeds, amdq, apdq);
     
     // check if sum of left/right going fluctuations sum to jump in flux
     double fl_local[10], fr_local[10];


### PR DESCRIPTION
A quick bug fix that was preventing the GPU ten-moment unit test from properly compiling with cuda. A couple function signatures weren't updated when the embedded geometry infrastructure was added.