### PR TITLE
Fix symlink creation in runregression

### DIFF
--- a/gkeyll/lua/Tool/runregression.lua
+++ b/gkeyll/lua/Tool/runregression.lua
@@ -1001,13 +1001,19 @@ local function prepareCRun(test, timeoutSecs, mode, skipCompile)
    end
 
    -- Symlink the layer source dir so tests can find data files by relative path.
+   -- Always recreate the link so it tracks the currently configured source_dir
+   -- (a stale link from a previous configure would point at the old tree).
+   -- Remove the old link first: 'ln -sf' onto a symlink-to-directory would
+   -- otherwise create the new link *inside* the old target.
+   -- Also uses only rm -f to avoid accidentally deleting a real directory
+   -- if for whatever reason a directory of the same name (vlasov or gyrokinetic)
+   -- exists at the location we are trying to make the symlink. 
    if test.layer_src then
       local layerSrcPath = configVals.source_dir .. "/" .. test.layer_src
       local symlinkPath  = runDir .. "/" .. test.layer_src
-      if lfs.attributes(layerSrcPath, "mode") == "directory"
-         and not lfs.attributes(symlinkPath) then
-         os.execute(string.format("ln -sf '%s' '%s' 2>/dev/null",
-            layerSrcPath, symlinkPath))
+      if lfs.attributes(layerSrcPath, "mode") == "directory" then
+         os.execute(string.format("rm -f '%s' && ln -s '%s' '%s' 2>/dev/null",
+            symlinkPath, layerSrcPath, symlinkPath))
       end
    end
 


### PR DESCRIPTION
If you look in individual runs for your runregression system, you will see a directory for that app layer (so all gyrokinetic/creg-runs have a gyrokinetic/ folder in them). This is a symlink to your source app-layer directory so that any C regression test can resolve relative paths to what we keep in that layers data/ directory (such as eqdsk files).

This symlink was only checking if it existed and then running, which could produce a silent failure if you switched source repositories and changed something about the underlying data (if some eqdsk file gets updated). So always create the symlink safely by rm -f and ln -s. Note the lack of -rf because we don't want to accidentally delete a directory and delete data. We let the rm command fail in that case.