### PR TITLE
[hot fix] Frame and time is not written properly in metadata

### DIFF
--- a/gyrokinetic/apps/gk_neut_species_fluid.c
+++ b/gyrokinetic/apps/gk_neut_species_fluid.c
@@ -254,8 +254,6 @@ gk_neut_species_fluid_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app,
 
   // Metadata for gk_neut_species app.
   struct gkyl_msgpack_map_elem io_meta[] = {
-    { .key = "time", .elem_type = GKYL_MP_DOUBLE, .dval = 0.0 },
-    { .key = "frame", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = 0 },
     { .key = "poly_order", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = ns->basis.poly_order },
     { .key = "basis_type", .elem_type = GKYL_MP_STRING, .cval = ns->basis.id }
   };

--- a/gyrokinetic/apps/gk_neut_species_kinetic.c
+++ b/gyrokinetic/apps/gk_neut_species_kinetic.c
@@ -707,8 +707,6 @@ gk_neut_species_kinetic_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *ap
 
   // Metadata for gk_neut_species app.
   struct gkyl_msgpack_map_elem io_meta[] = {
-    { .key = "time", .elem_type = GKYL_MP_DOUBLE, .dval = 0.0 },
-    { .key = "frame", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = 0 },
     { .key = "poly_order", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = s->basis.poly_order },
     { .key = "basis_type", .elem_type = GKYL_MP_STRING, .cval = s->basis.id }
   };

--- a/gyrokinetic/apps/gk_species.c
+++ b/gyrokinetic/apps/gk_species.c
@@ -1500,8 +1500,6 @@ gk_species_init(struct gkyl_gk *gk_app_inp, struct gkyl_gyrokinetic_app *app, st
  
   // Metadata for gk_species app.
   struct gkyl_msgpack_map_elem io_meta[] = {
-    { .key = "time", .elem_type = GKYL_MP_DOUBLE, .dval = 0.0 },
-    { .key = "frame", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = 0 },
     { .key = "poly_order", .elem_type = GKYL_MP_UNSIGNED_INT, .uval = gks->basis.poly_order },
     { .key = "basis_type", .elem_type = GKYL_MP_STRING, .cval = gks->basis.id }
   };


### PR DESCRIPTION
Remove some conflicting lines that were not allowing the frame and time in the metadata to be properly written in phase space array writes. This prevents restarts with `-r` option in GK so it's pretty urgent to fix.

This bug was introduced in the merge of #1053

#### Note
This bug was not easy to catch because we usually don't test restarts with `-r` option. One could think of setting a test like that in the future.