### PR TITLE
Add _inew and _new interfaces for array_avg updater

### DIFF
--- a/core/unit/ctest_array_average.c
+++ b/core/unit/ctest_array_average.c
@@ -131,7 +131,7 @@ void test_1x(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *avg_full = gkyl_array_average_new(&inp_avg_full);
+  struct gkyl_array_average *avg_full = gkyl_array_average_inew(&inp_avg_full);
 
   struct gkyl_array *avgf_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(avg_full, fx_c, avgf_c);
@@ -241,7 +241,7 @@ void test_2x_1step(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_xy,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *avg_xy = gkyl_array_average_new(&inp_avg_xy);
+  struct gkyl_array_average *avg_xy = gkyl_array_average_inew(&inp_avg_xy);
 
   struct gkyl_array *avgf_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(avg_xy, fxy_c, avgf_c);
@@ -332,7 +332,7 @@ void test_2x_intx_inty(int poly_order, bool use_gpu)
     .avg_dim = int_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_x = gkyl_array_average_new(&inp_int_x);
+  struct gkyl_array_average *int_x = gkyl_array_average_inew(&inp_int_x);
 
   struct gkyl_array *wy_c = mkarr(basis_y.num_basis, local_y_ext.volume, use_gpu);
   gkyl_array_average_advance(int_x, wxy_c, wy_c);
@@ -352,7 +352,7 @@ void test_2x_intx_inty(int poly_order, bool use_gpu)
     .avg_dim = int_dim_y,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_y = gkyl_array_average_new(&inp_int_y);
+  struct gkyl_array_average *int_y = gkyl_array_average_inew(&inp_int_y);
 
   struct gkyl_array *intw_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(int_y, wy_c, intw_c);
@@ -460,7 +460,7 @@ void test_2x_avgx_avgy(int poly_order, bool use_gpu)
   };
   struct gkyl_array *fy_c = mkarr(basis_y.num_basis, local_y_ext.volume, use_gpu);
 
-  struct gkyl_array_average *avg_x = gkyl_array_average_new(&inp_avg_x);
+  struct gkyl_array_average *avg_x = gkyl_array_average_inew(&inp_avg_x);
   gkyl_array_average_advance(avg_x, fxy_c, fy_c); // fy_c is DG coeff of int[w(x,y) f(x,y)]dx / int[w(x,y)]dx
   
   gkyl_array_average_release(avg_x);
@@ -477,7 +477,7 @@ void test_2x_avgx_avgy(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_x = gkyl_array_average_new(&inp_int_x);
+  struct gkyl_array_average *int_x = gkyl_array_average_inew(&inp_int_x);
 
   struct gkyl_array *wy_c = mkarr(basis_y.num_basis, local_y_ext.volume, use_gpu);
   gkyl_array_average_advance(int_x, wxy_c, wy_c); // wy_c is DG coeff of int[w(x,y)]dx
@@ -500,7 +500,7 @@ void test_2x_avgx_avgy(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_y,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_y = gkyl_array_average_new(&inp_int_y);
+  struct gkyl_array_average *int_y = gkyl_array_average_inew(&inp_int_y);
 
   struct gkyl_array *intf_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(int_y, fy_c, intf_c); // intf_c is DG coeff of int[int[w(x,y) f(x,y)]dx]dy
@@ -621,7 +621,7 @@ void test_2x_avgy_avgx(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_y,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *avg_x = gkyl_array_average_new(&inp_avg_x);
+  struct gkyl_array_average *avg_x = gkyl_array_average_inew(&inp_avg_x);
 
   struct gkyl_array *fx_c = mkarr(basis_x.num_basis, local_x_ext.volume, use_gpu);
 
@@ -641,7 +641,7 @@ void test_2x_avgy_avgx(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_y,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_x = gkyl_array_average_new(&inp_int_x);
+  struct gkyl_array_average *int_x = gkyl_array_average_inew(&inp_int_x);
 
   struct gkyl_array *wx_c = mkarr(basis_x.num_basis, local_x_ext.volume, use_gpu);
   gkyl_array_average_advance(int_x, wxy_c, wx_c); // wx_c is DG coeff of int[w(x,y)]dx
@@ -664,7 +664,7 @@ void test_2x_avgy_avgx(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_y = gkyl_array_average_new(&inp_int_y);
+  struct gkyl_array_average *int_y = gkyl_array_average_inew(&inp_int_y);
 
   struct gkyl_array *intf_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(int_y, fx_c, intf_c); // intf_c is DG coeff of int[int[w(x,y) f(x,y)]dx]dy
@@ -811,7 +811,7 @@ void test_3x_avgx_avgyz(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *avg_xyz_to_yz = gkyl_array_average_new(&inp_avg_xyz_to_yz);
+  struct gkyl_array_average *avg_xyz_to_yz = gkyl_array_average_inew(&inp_avg_xyz_to_yz);
 
   struct gkyl_array *fyz_c = mkarr(basis_yz.num_basis, local_yz_ext.volume, use_gpu);
   gkyl_array_average_advance(avg_xyz_to_yz, fxyz_c, fyz_c); // fy_c is DG coeff of int[w(x,y,z) f(x,y,z)]dx / int[w(x,y,z)]dx
@@ -829,7 +829,7 @@ void test_3x_avgx_avgyz(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_xyz_to_yz = gkyl_array_average_new(&inp_int_xyz_to_yz);
+  struct gkyl_array_average *int_xyz_to_yz = gkyl_array_average_inew(&inp_int_xyz_to_yz);
 
   struct gkyl_array *wyz_c = mkarr(basis_yz.num_basis, local_yz_ext.volume, use_gpu);
   gkyl_array_average_advance(int_xyz_to_yz, wxyz_c, wyz_c); // wy_c is DG coeff of int[w(x,y)]dy
@@ -851,7 +851,7 @@ void test_3x_avgx_avgyz(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_yz,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_yz = gkyl_array_average_new(&inp_int_yz);
+  struct gkyl_array_average *int_yz = gkyl_array_average_inew(&inp_int_yz);
 
   struct gkyl_array *intf_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(int_yz, fyz_c, intf_c); // intf_c is DG coeff of int[int[w(x,y) f(x,y)]dy]dx
@@ -974,7 +974,7 @@ void test_3x_avgyz_avgx(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_yz,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *avg_xyz_to_x = gkyl_array_average_new(&inp_avg_xyz_to_x);
+  struct gkyl_array_average *avg_xyz_to_x = gkyl_array_average_inew(&inp_avg_xyz_to_x);
 
   struct gkyl_array *fx_c = mkarr(basis_x.num_basis, local_x_ext.volume, use_gpu);
   gkyl_array_average_advance(avg_xyz_to_x, fxyz_c, fx_c); // 
@@ -993,7 +993,7 @@ void test_3x_avgyz_avgx(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_yz,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_xyz_to_x = gkyl_array_average_new(&inp_int_xyz_to_x);
+  struct gkyl_array_average *int_xyz_to_x = gkyl_array_average_inew(&inp_int_xyz_to_x);
 
   struct gkyl_array *wx_c = mkarr(basis_x.num_basis, local_x_ext.volume, use_gpu);
   gkyl_array_average_advance(int_xyz_to_x, wxyz_c, wx_c); // wy_c is DG coeff of int[w(x,y)]dydz
@@ -1016,7 +1016,7 @@ void test_3x_avgyz_avgx(int poly_order, bool use_gpu)
     .avg_dim = avg_dim_x,
     .use_gpu = use_gpu
   };
-  struct gkyl_array_average *int_x = gkyl_array_average_new(&inp_int_x);
+  struct gkyl_array_average *int_x = gkyl_array_average_inew(&inp_int_x);
 
   struct gkyl_array *intf_c = mkarr(red_basis.num_basis, red_local.volume, use_gpu);
   gkyl_array_average_advance(int_x, fx_c, intf_c); // intf_c is DG coeff of int[int[int[w(x,y) f(x,y)]dy]dz]dx

--- a/core/zero/array_average.c
+++ b/core/zero/array_average.c
@@ -6,8 +6,27 @@
 
 #include <assert.h>
 
+struct gkyl_array_average* gkyl_array_average_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, 
+  const struct gkyl_basis basis_avg, const struct gkyl_range *local, const struct gkyl_range *local_avg, 
+  const struct gkyl_range *local_avg_ext, const struct gkyl_array *weight, const int *avg_dim, bool use_gpu)
+{
+  return gkyl_array_average_inew(
+    &(struct gkyl_array_average_inp) {
+      .grid = grid,
+      .basis = basis,
+      .basis_avg = basis_avg,
+      .local = local,
+      .local_avg = local_avg,
+      .local_avg_ext = local_avg_ext,
+      .weight = weight,
+      .avg_dim = avg_dim,
+      .use_gpu = use_gpu
+    }
+  );
+}
+
 struct gkyl_array_average*
-gkyl_array_average_new(const struct gkyl_array_average_inp *inp)
+gkyl_array_average_inew(const struct gkyl_array_average_inp *inp)
 {
   // works for p <=2 only due to the gkyl_dg_div_op_range call in advance
   assert(inp->basis.poly_order <= 2); 
@@ -76,7 +95,7 @@ gkyl_array_average_new(const struct gkyl_array_average_inp *inp)
       .avg_dim = inp->avg_dim,
       .use_gpu = inp->use_gpu
     };
-    struct gkyl_array_average *int_w = gkyl_array_average_new(&inp_integral);
+    struct gkyl_array_average *int_w = gkyl_array_average_inew(&inp_integral);
     // run the updater to integrate the weight
     gkyl_array_average_advance(int_w, inp->weight, up->weight_avg);
     gkyl_array_average_release(int_w);

--- a/core/zero/array_average.c
+++ b/core/zero/array_average.c
@@ -6,15 +6,15 @@
 
 #include <assert.h>
 
-struct gkyl_array_average* gkyl_array_average_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, 
-  const struct gkyl_basis basis_avg, const struct gkyl_range *local, const struct gkyl_range *local_avg, 
+struct gkyl_array_average* gkyl_array_average_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis *basis,
+  const struct gkyl_basis *basis_avg, const struct gkyl_range *local, const struct gkyl_range *local_avg,
   const struct gkyl_range *local_avg_ext, const struct gkyl_array *weight, const int *avg_dim, bool use_gpu)
 {
   return gkyl_array_average_inew(
     &(struct gkyl_array_average_inp) {
       .grid = grid,
-      .basis = basis,
-      .basis_avg = basis_avg,
+      .basis = *basis,
+      .basis_avg = *basis_avg,
       .local = local,
       .local_avg = local_avg,
       .local_avg_ext = local_avg_ext,

--- a/core/zero/gkyl_array_average.h
+++ b/core/zero/gkyl_array_average.h
@@ -67,7 +67,25 @@ struct gkyl_array_average_inp {
  * @param inp see gkyl_array_average_inp structure
  */
 struct gkyl_array_average*
-gkyl_array_average_new(const struct gkyl_array_average_inp *inp);
+gkyl_array_average_inew(const struct gkyl_array_average_inp *inp);
+
+/**
+ * Create a new updater that computes the weighted average of a gkyl_array.
+ * 
+ * @param grid Pointer to the computational grid, used to compute the surface element.
+ * @param basis Total basis, describes the full dimensionality (ndim), polynomial type, and order.
+ * @param basis_avg Subset basis, describes the reduced dimensionality, polynomial type, and order for the output.
+ * @param local Full range of the input array, covering all dimensions of the total basis.
+ * @param local_avg Reduced range of the output array, covering only the non-averaged dimensions.
+ * @param local_avg_ext Extended reduced range of the output array, used only to define the integrated weight.
+ * @param weight Pointer to the array containing weight for the averaging process. (set it to NULL for integral)
+ * @param avg_dim Flag array to set which dimension is averaged
+ * @param use_gpu Boolean flag indicating whether the computation should be performed on a GPU.
+ */
+struct gkyl_array_average*
+gkyl_array_average_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, 
+  const struct gkyl_basis basis_avg, const struct gkyl_range *local, const struct gkyl_range *local_avg, 
+  const struct gkyl_range *local_avg_ext, const struct gkyl_array *weight, const int *avg_dim, bool use_gpu);
 
 /**
  * Compute the array average. Note: the weight is linked to the updater.

--- a/core/zero/gkyl_array_average.h
+++ b/core/zero/gkyl_array_average.h
@@ -83,8 +83,8 @@ gkyl_array_average_inew(const struct gkyl_array_average_inp *inp);
  * @param use_gpu Boolean flag indicating whether the computation should be performed on a GPU.
  */
 struct gkyl_array_average*
-gkyl_array_average_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis basis, 
-  const struct gkyl_basis basis_avg, const struct gkyl_range *local, const struct gkyl_range *local_avg, 
+gkyl_array_average_new(const struct gkyl_rect_grid *grid, const struct gkyl_basis *basis,
+  const struct gkyl_basis *basis_avg, const struct gkyl_range *local, const struct gkyl_range *local_avg,
   const struct gkyl_range *local_avg_ext, const struct gkyl_array *weight, const int *avg_dim, bool use_gpu);
 
 /**

--- a/vlasov/zero/dg_calc_canonical_pb_fluid_vars.c
+++ b/vlasov/zero/dg_calc_canonical_pb_fluid_vars.c
@@ -66,7 +66,7 @@ gkyl_dg_calc_canonical_pb_fluid_vars_new(const struct gkyl_rect_grid *conf_grid,
         .avg_dim = int_dim_y,
         .use_gpu = use_gpu
       };
-      up->int_y = gkyl_array_average_new(&inp_int_y);
+      up->int_y = gkyl_array_average_inew(&inp_int_y);
       up->phi_zonal = gkyl_array_new(GKYL_DOUBLE, basis_x.num_basis, up->x_local_ext.volume);
       up->n_zonal = gkyl_array_new(GKYL_DOUBLE, basis_x.num_basis, up->x_local_ext.volume);
       up->subtract_zonal = choose_canonical_pb_fluid_subtract_zonal_kern(conf_basis->b_type, cdim, poly_order);

--- a/vlasov/zero/dg_calc_canonical_pb_fluid_vars_cu.cu
+++ b/vlasov/zero/dg_calc_canonical_pb_fluid_vars_cu.cu
@@ -245,7 +245,7 @@ gkyl_dg_calc_canonical_pb_fluid_vars_cu_dev_new(const struct gkyl_rect_grid *con
         .avg_dim = int_dim_y,
         .use_gpu = true, // We will perform the average on GPUs
       };
-      up->int_y = gkyl_array_average_new(&inp_int_y);
+      up->int_y = gkyl_array_average_inew(&inp_int_y);
       up->phi_zonal = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis_x.num_basis, up->x_local_ext.volume);
       up->n_zonal = gkyl_array_cu_dev_new(GKYL_DOUBLE, basis_x.num_basis, up->x_local_ext.volume);
     }    


### PR DESCRIPTION
We need an interface with a direct access to parameter of array average to link it with postgkyl in https://github.com/ammarhakim/postgkyl/pull/222.

This PR implements it and now array_avg follows the ideas of having a `_new` routine with direct arguments and a `_inew` interface where we can pass an input structure.