### PR TITLE
Makefiles `check` summary and `make unit-run` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,8 +353,6 @@ gyrokinetic: vlasov  ## Build Gyrokinetic infrastructure code
 gyrokinetic-unit: gyrokinetic vlasov-unit ## Build Gyrokinetic unit tests
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic unit
 
-gyrokinetic-unit: gyrokinetic-unit-compile gyrokinetic-unit-run ## Build and run Gyrokinetic unit tests
-
 gyrokinetic-regression: gyrokinetic vlasov-regression ## Build Gyrokinetic regression tests
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic regression
 

--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,22 @@ clean:
 	rm -rf ${BUILD_DIR}
 
 # Check everything
-check: core-check moments-check vlasov-check gyrokinetic-check pkpm-check ## Run all unit tests
+check: unit
+	@export GKYL_TEST_LOG=$$(mktemp); : > "$$GKYL_TEST_LOG"; \
+	for app in core moments vlasov gyrokinetic pkpm; do \
+	  $(MAKE) -C $$app -f Makefile-$$app check; \
+	done; \
+	npass=$$(grep -c '^PASS ' "$$GKYL_TEST_LOG"); \
+	nfail=$$(grep -c '^FAIL ' "$$GKYL_TEST_LOG"); \
+	ntot=$$((npass+nfail)); \
+	echo "==================== gkeyll unit test summary ===================="; \
+	echo "Total: $$ntot   Passed: $$npass   Failed: $$nfail"; \
+	if [ $$nfail -gt 0 ]; then \
+	  echo "Failed tests:"; \
+	  grep '^FAIL ' "$$GKYL_TEST_LOG" | sed 's/^FAIL /  /'; \
+	  rm -f "$$GKYL_TEST_LOG"; \
+	  exit 1; \
+	fi
 
 # From: https://www.client9.com/self-documenting-makefiles/
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,11 @@ core-install: ## Install core infrastructure code
 core-clean: ## Clean core infrastructure code
 	cd core && $(MAKE) -f Makefile-core clean
 
-core-check: core ## Run unit tests in core
+core-check: core ## (Re)build and run unit tests in core
 	cd core && $(MAKE) -f Makefile-core check
+
+core-unit-run: ## Run core unit tests
+	cd core && $(MAKE) -f Makefile-core unit-run
 
 core-valcheck: core ## Run valgrind on unit tests in core
 	cd core && $(MAKE) -f Makefile-core valcheck
@@ -308,8 +311,11 @@ moments-install: core-install ## Install moments infrastructure code
 moments-clean: ## Clean moments infrastructure code
 	cd moments && $(MAKE) -f Makefile-moments clean
 
-moments-check: moments ## Run unit tests in moments
+moments-check: moments ## (Re)build and run unit tests in moments
 	cd moments && $(MAKE) -f Makefile-moments check
+
+moments-unit-run: ## Run moments unit tests
+	cd moments && $(MAKE) -f Makefile-moments unit-run
 
 moments-valcheck: moments ## Run valgrind on unit tests in moments
 	cd moments && $(MAKE) -f Makefile-moments valcheck
@@ -331,8 +337,11 @@ vlasov-install: moments-install ## Install Vlasov infrastructure code
 vlasov-clean: ## Clean Vlasov infrastructure code
 	cd vlasov && $(MAKE) -f Makefile-vlasov clean
 
-vlasov-check: vlasov ## Run unit tests in Vlasov
+vlasov-check: vlasov ## (Re)build and run unit tests in Vlasov
 	cd vlasov && $(MAKE) -f Makefile-vlasov check
+
+vlasov-unit-run: ## Run Vlasov unit tests
+	cd vlasov && $(MAKE) -f Makefile-vlasov unit-run
 
 vlasov-valcheck: vlasov ## Run valgrind on unit tests in Vlasov
 	cd vlasov && $(MAKE) -f Makefile-vlasov valcheck
@@ -344,6 +353,8 @@ gyrokinetic: vlasov  ## Build Gyrokinetic infrastructure code
 gyrokinetic-unit: gyrokinetic vlasov-unit ## Build Gyrokinetic unit tests
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic unit
 
+gyrokinetic-unit: gyrokinetic-unit-compile gyrokinetic-unit-run ## Build and run Gyrokinetic unit tests
+
 gyrokinetic-regression: gyrokinetic vlasov-regression ## Build Gyrokinetic regression tests
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic regression
 
@@ -354,8 +365,11 @@ gyrokinetic-install: vlasov-install ## Install Gyrokinetic infrastructure code
 gyrokinetic-clean: ## Clean Gyrokinetic infrastructure code
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic clean
 
-gyrokinetic-check: gyrokinetic ## Run unit tests in Gyrokinetics
+gyrokinetic-check: gyrokinetic ## (Re)build and run unit tests in Gyrokinetics
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic check
+
+gyrokinetic-unit-run: ## Run Gyrokinetic unit tests
+	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic unit-run
 
 gyrokinetic-valcheck: gyrokinetic ## Run valgrind on unit tests in Gyrokinetics
 	cd gyrokinetic && $(MAKE) -f Makefile-gyrokinetic valcheck
@@ -377,8 +391,11 @@ pkpm-install: gyrokinetic-install ## Install PKPM infrastructure code
 pkpm-clean: ## Clean PKPM infrastructure code
 	cd pkpm && $(MAKE) -f Makefile-pkpm clean
 
-pkpm-check: pkpm ## Run unit tests in PKPM
+pkpm-check: pkpm ## (Re)build and run unit tests in PKPM
 	cd pkpm && $(MAKE) -f Makefile-pkpm check
+
+pkpm-unit-run: ## Run PKPM unit tests
+	cd pkpm && $(MAKE) -f Makefile-pkpm unit-run
 
 pkpm-valcheck: pkpm ## Run valgrind on unit tests in PKPM
 	cd pkpm && $(MAKE) -f Makefile-pkpm valcheck
@@ -392,7 +409,7 @@ gkeyll-install: ${BUILD_APP}-install gkeyll ## Install Gkeyll executable
 
 ## Targets to build things all parts of the code
 
-# build all unit tests 
+# build all unit tests
 unit: pkpm-unit gyrokinetic-unit vlasov-unit moments-unit core-unit ## Build all unit tests
 
 # build all regression tests 
@@ -403,10 +420,13 @@ clean:
 	rm -rf ${BUILD_DIR}
 
 # Check everything
-check: unit
+check: unit unit-run ## Build (if needed) and run all unit tests
+
+# Run all unit tests
+unit-run: ## Run all unit tests without (re)building them
 	@export GKYL_TEST_LOG=$$(mktemp); : > "$$GKYL_TEST_LOG"; \
 	for app in core moments vlasov gyrokinetic pkpm; do \
-	  $(MAKE) -C $$app -f Makefile-$$app check; \
+	  $(MAKE) -C $$app -f Makefile-$$app unit-run; \
 	done; \
 	npass=$$(grep -c '^PASS ' "$$GKYL_TEST_LOG"); \
 	nfail=$$(grep -c '^FAIL ' "$$GKYL_TEST_LOG"); \

--- a/core/Makefile-core
+++ b/core/Makefile-core
@@ -142,7 +142,26 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); cd ../; ./core/$(unit) -E; cd core;)
+	@cd ..; app=core; own_log=0; \
+	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
+	npass=0; nfail=0; \
+	for unit in ${UNITS}; do \
+	  tname=$$(basename $$unit); \
+	  if ./$$app/$$unit -E; then \
+	    npass=$$((npass+1)); echo "PASS $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  else \
+	    nfail=$$((nfail+1)); echo "FAIL $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  fi; \
+	done; \
+	if [ $$own_log -eq 1 ]; then \
+	  echo "==================== $$app test summary ===================="; \
+	  echo "Passed: $$npass   Failed: $$nfail"; \
+	  if [ $$nfail -gt 0 ]; then \
+	    echo "Failed tests:"; grep '^FAIL ' "$$GKYL_TEST_LOG" | sed 's/^FAIL /  /'; rm -f "$$GKYL_TEST_LOG"; exit 1; \
+	  else \
+	    echo "All $$app unit tests passed."; rm -f "$$GKYL_TEST_LOG"; \
+	  fi; \
+	fi
 
 valcheck: unit ## Run valgrind on unit test
 	cd ../ && $(foreach unit,$(UNITS),valgrind --leak-check=full ./$(patsubst ../%,%,$(unit)) -E 2>./$(patsubst ../%,%,$(unit))_val_err 1>/dev/null;)

--- a/core/Makefile-core
+++ b/core/Makefile-core
@@ -141,7 +141,10 @@ endif
 
 .PHONY: check valcheck
 # Run all unit tests
-check: unit ## Build (if needed) and run all unit tests
+check: unit unit-run ## Build (if needed) and run all unit tests
+
+# Run all unit tests without (re)building them
+unit-run: ## Run unit tests without (re)building them
 	@cd ..; app=core; own_log=0; \
 	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
 	npass=0; nfail=0; \

--- a/gyrokinetic/Makefile-gyrokinetic
+++ b/gyrokinetic/Makefile-gyrokinetic
@@ -209,7 +209,10 @@ endif
 
 .PHONY: check valcheck
 # Run all unit tests
-check: unit ## Build (if needed) and run all unit tests
+check: unit unit-run ## Build (if needed) and run all unit tests
+
+# Run all unit tests without (re)building them
+unit-run: ## Run unit tests without (re)building them
 	@cd ..; app=gyrokinetic; own_log=0; \
 	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
 	npass=0; nfail=0; \

--- a/gyrokinetic/Makefile-gyrokinetic
+++ b/gyrokinetic/Makefile-gyrokinetic
@@ -143,6 +143,14 @@ ifdef USING_NVCC
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCS) -c $< -o $@
 
+../$(BUILD_DIR)/gyrokinetic/$(KERNELS_DIR)/dg_gyrokinetic_passive/%.c.o : $(KERNELS_DIR)/dg_gyrokinetic_passive/%.c
+	$(MKDIR_P) $(dir $@)
+	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCS) -c $< -o $@
+
+../$(BUILD_DIR)/gyrokinetic/$(KERNELS_DIR)/gk_collisionless_passive_flux/%.c.o : $(KERNELS_DIR)/gk_collisionless_passive_flux/%.c
+	$(MKDIR_P) $(dir $@)
+	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCS) -c $< -o $@
+
 ../$(BUILD_DIR)/gyrokinetic/$(KERNELS_DIR)/bc_sheath_gyrokinetic/%.c.o : $(KERNELS_DIR)/bc_sheath_gyrokinetic/%.c
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCS) -c $< -o $@
@@ -175,7 +183,7 @@ ifdef USING_NVCC
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCS) -c $< -o $@
 
-../$(BUILD_DIR)/gyrokinetic/$(KERNELS_DIR)/twistshift/%.c.o : $(KERNELS_DIR)/twistshift/%.c
+../$(BUILD_DIR)/gyrokinetic/$(KERNELS_DIR)/twistshift_dg/%.c.o : $(KERNELS_DIR)/twistshift_dg/%.c
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CFLAGS) $(NVCC_FLAGS) $(INCS) -c $< -o $@
 
@@ -202,7 +210,26 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); cd ../; ./gyrokinetic/$(unit) -E; cd gyrokinetic;)
+	@cd ..; app=gyrokinetic; own_log=0; \
+	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
+	npass=0; nfail=0; \
+	for unit in ${UNITS}; do \
+	  tname=$$(basename $$unit); \
+	  if ./$$app/$$unit -E; then \
+	    npass=$$((npass+1)); echo "PASS $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  else \
+	    nfail=$$((nfail+1)); echo "FAIL $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  fi; \
+	done; \
+	if [ $$own_log -eq 1 ]; then \
+	  echo "==================== $$app test summary ===================="; \
+	  echo "Passed: $$npass   Failed: $$nfail"; \
+	  if [ $$nfail -gt 0 ]; then \
+	    echo "Failed tests:"; grep '^FAIL ' "$$GKYL_TEST_LOG" | sed 's/^FAIL /  /'; rm -f "$$GKYL_TEST_LOG"; exit 1; \
+	  else \
+	    echo "All $$app unit tests passed."; rm -f "$$GKYL_TEST_LOG"; \
+	  fi; \
+	fi
 
 valcheck: unit ## Run valgrind on unit test
 	cd ../ && $(foreach unit,$(UNITS),valgrind --leak-check=full ./$(patsubst ../%,%,$(unit)) -E 2>./$(patsubst ../%,%,$(unit))_val_err 1>/dev/null;)

--- a/moments/Makefile-moments
+++ b/moments/Makefile-moments
@@ -116,7 +116,10 @@ endif
 
 .PHONY: check valcheck
 # Run all unit tests
-check: unit ## Build (if needed) and run all unit tests
+check: unit unit-run ## Build (if needed) and run all unit tests
+
+# Run all unit tests without (re)building them
+unit-run: ## Run unit tests without (re)building them
 	@cd ..; app=moments; own_log=0; \
 	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
 	npass=0; nfail=0; \

--- a/moments/Makefile-moments
+++ b/moments/Makefile-moments
@@ -117,7 +117,26 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); cd ../; ./moments/$(unit) -E; cd moments;)
+	@cd ..; app=moments; own_log=0; \
+	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
+	npass=0; nfail=0; \
+	for unit in ${UNITS}; do \
+	  tname=$$(basename $$unit); \
+	  if ./$$app/$$unit -E; then \
+	    npass=$$((npass+1)); echo "PASS $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  else \
+	    nfail=$$((nfail+1)); echo "FAIL $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  fi; \
+	done; \
+	if [ $$own_log -eq 1 ]; then \
+	  echo "==================== $$app test summary ===================="; \
+	  echo "Passed: $$npass   Failed: $$nfail"; \
+	  if [ $$nfail -gt 0 ]; then \
+	    echo "Failed tests:"; grep '^FAIL ' "$$GKYL_TEST_LOG" | sed 's/^FAIL /  /'; rm -f "$$GKYL_TEST_LOG"; exit 1; \
+	  else \
+	    echo "All $$app unit tests passed."; rm -f "$$GKYL_TEST_LOG"; \
+	  fi; \
+	fi
 
 valcheck: unit ## Run valgrind on unit test
 	cd ../ && $(foreach unit,$(UNITS),valgrind --leak-check=full ./$(patsubst ../%,%,$(unit)) -E 2>./$(patsubst ../%,%,$(unit))_val_err 1>/dev/null;)

--- a/pkpm/Makefile-pkpm
+++ b/pkpm/Makefile-pkpm
@@ -108,7 +108,10 @@ endif
 
 .PHONY: check valcheck
 # Run all unit tests
-check: unit ## Build (if needed) and run all unit tests
+check: unit unit-run ## Build (if needed) and run all unit tests
+
+# Run all unit tests without (re)building them
+unit-run: ## Run unit tests without (re)building them
 	@cd ..; app=pkpm; own_log=0; \
 	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
 	npass=0; nfail=0; \

--- a/pkpm/Makefile-pkpm
+++ b/pkpm/Makefile-pkpm
@@ -109,7 +109,26 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); cd ../; ./pkpm/$(unit) -E; cd pkpm;)
+	@cd ..; app=pkpm; own_log=0; \
+	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
+	npass=0; nfail=0; \
+	for unit in ${UNITS}; do \
+	  tname=$$(basename $$unit); \
+	  if ./$$app/$$unit -E; then \
+	    npass=$$((npass+1)); echo "PASS $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  else \
+	    nfail=$$((nfail+1)); echo "FAIL $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  fi; \
+	done; \
+	if [ $$own_log -eq 1 ]; then \
+	  echo "==================== $$app test summary ===================="; \
+	  echo "Passed: $$npass   Failed: $$nfail"; \
+	  if [ $$nfail -gt 0 ]; then \
+	    echo "Failed tests:"; grep '^FAIL ' "$$GKYL_TEST_LOG" | sed 's/^FAIL /  /'; rm -f "$$GKYL_TEST_LOG"; exit 1; \
+	  else \
+	    echo "All $$app unit tests passed."; rm -f "$$GKYL_TEST_LOG"; \
+	  fi; \
+	fi
 
 valcheck: unit ## Run valgrind on unit test
 	$(foreach unit,$(UNITS),valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --show-error-list=yes $(unit) --exec=never 2>$(unit)_val_err 1>/dev/null;)

--- a/vlasov/Makefile-vlasov
+++ b/vlasov/Makefile-vlasov
@@ -161,7 +161,26 @@ endif
 .PHONY: check valcheck
 # Run all unit tests
 check: unit ## Build (if needed) and run all unit tests
-	$(foreach unit,${UNITS},echo $(unit); cd ../; ./vlasov/$(unit) -E; cd vlasov;)
+	@cd ..; app=vlasov; own_log=0; \
+	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
+	npass=0; nfail=0; \
+	for unit in ${UNITS}; do \
+	  tname=$$(basename $$unit); \
+	  if ./$$app/$$unit -E; then \
+	    npass=$$((npass+1)); echo "PASS $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  else \
+	    nfail=$$((nfail+1)); echo "FAIL $$app: $$tname" >> "$$GKYL_TEST_LOG"; \
+	  fi; \
+	done; \
+	if [ $$own_log -eq 1 ]; then \
+	  echo "==================== $$app test summary ===================="; \
+	  echo "Passed: $$npass   Failed: $$nfail"; \
+	  if [ $$nfail -gt 0 ]; then \
+	    echo "Failed tests:"; grep '^FAIL ' "$$GKYL_TEST_LOG" | sed 's/^FAIL /  /'; rm -f "$$GKYL_TEST_LOG"; exit 1; \
+	  else \
+	    echo "All $$app unit tests passed."; rm -f "$$GKYL_TEST_LOG"; \
+	  fi; \
+	fi
 
 valcheck: unit ## Run valgrind on unit test
 	cd ../ && $(foreach unit,$(UNITS),valgrind --leak-check=full ./$(patsubst ../%,%,$(unit)) -E 2>./$(patsubst ../%,%,$(unit))_val_err 1>/dev/null;)

--- a/vlasov/Makefile-vlasov
+++ b/vlasov/Makefile-vlasov
@@ -160,7 +160,10 @@ endif
 
 .PHONY: check valcheck
 # Run all unit tests
-check: unit ## Build (if needed) and run all unit tests
+check: unit unit-run ## Build (if needed) and run all unit tests
+
+# Run all unit tests without (re)building them
+unit-run: ## Run unit tests without (re)building them
 	@cd ..; app=vlasov; own_log=0; \
 	if [ -z "$$GKYL_TEST_LOG" ]; then GKYL_TEST_LOG=$$(mktemp); own_log=1; fi; \
 	npass=0; nfail=0; \


### PR DESCRIPTION
This PR wants to add two things to the interface with Gkeyll `Make` commands:

1. a summary at the end of the `make [app-]check` command to provide a clear list of failed tests.
2. a new `make [app-]unit-run` to be able to run the unit test without compilation.

We don't change the behavior of `make [app-]check` or other existing commands.

## 1. Test summary
We propose to improve the interface of the `check` commands in the `Makefile` for Gkeyll and its apps. In this branch, `make check` will end like:
```
==================== gkeyll unit test summary ====================
Total: 127   Passed: 119   Failed: 8
Failed tests:
  moments: ctest_wv_vacuum_einstein_conformal
  gyrokinetic: ctest_bc_twistshift
  gyrokinetic: ctest_dg_gyrokinetic_kern_tm
  gyrokinetic: ctest_fem_parproj
  gyrokinetic: ctest_gk_geometry_tok
  gyrokinetic: ctest_gyrokinetic_cross_prim_moms_bgk
  gyrokinetic: ctest_mom_gyrokinetic
  gyrokinetic: ctest_rescale_ghost_jacf
make: *** [check] Error 1
```
So that we see directly what failed. 

If we use app specific unit test suite it will display like `make moments-check`
```
==================== moments test summary ====================
Passed: 30   Failed: 1
Failed tests:
  moments: ctest_wv_vacuum_einstein_conformal
make[1]: *** [check] Error 1
make: *** [moments-check] Error 2
```

### Functionning
The app-specific makefile check uses now each unit test in an `if` statement to count the number of passing/failing test and also write a message in a log variable. This log variable is built with "PASS" or "FAIL" followed by the app name and test name. If the app-specific makefile check is run directly, this will be used to write down which are the failing tests. If the global makefile check is run, each app-specific makefile check will happen their message into a global log.

## 2. Split between compilation and run
We introduce the new `unit-run` make command to only run the unit test. This is useful for clusters where the code should be compiled on login node and not on compute node (e.g. stellar does not allow access to the libs from compute nodes).

## Note on CPU vs GPU failing tests
We do not differentiate failure of CPU or GPU test. The test is considered as failing as soon as one subtest in the unit test is failing. One could consider differentiating them but the nomenclature of GPU and CPU test is not unified (sometimes it's `_dev` sometimes `_gpu` sometimes `_ho` vs `_dev`). Trying to differentiate CPU and GPU tests inside the Makefile logics would be cumbersome.
