### PR TITLE
Position map consistency check

### DIFF
--- a/gyrokinetic/zero/gkyl_position_map_priv.h
+++ b/gyrokinetic/zero/gkyl_position_map_priv.h
@@ -673,18 +673,6 @@ position_map_constB_z_numeric(double t, const double *xn, double *fout, void *ct
   if (enable_limits_min_B || enable_limits_max_B)
   {
     // Set a minimum cell size on the edges.
-    // Theta_left/Theta_right are the physical (non-uniform) locations of the
-    // extrema bracketing this dB-accumulation region. theta lives in a
-    // different (uniform) coordinate, and the region's own span in that
-    // coordinate, [theta_bound_lower, theta_bound_upper], is generally NOT
-    // the same width as [Theta_left, Theta_right] -- regions accumulate
-    // equal dB, not equal theta or equal Theta. Anchoring the straight-line
-    // caps directly on raw theta (assuming theta ~= Theta_left/Theta_right)
-    // is only valid right at the region boundary; pivot on theta_bound_lower/
-    // upper instead so the cap is evaluated in the same coordinate as theta
-    // everywhere in the region (this matters most when a caller, e.g. the
-    // Gaussian smoothing quadrature, evaluates theta values whose own region
-    // is much narrower or wider in Theta-space than in theta-space).
     double Theta_left  = interval_lower;
     double Theta_right = interval_upper;
     double dB_this_region = fabs(gpm->constB_ctx->bmag_extrema[region+1] - gpm->constB_ctx->bmag_extrema[region]);

--- a/gyrokinetic/zero/gkyl_position_map_priv.h
+++ b/gyrokinetic/zero/gkyl_position_map_priv.h
@@ -672,11 +672,25 @@ position_map_constB_z_numeric(double t, const double *xn, double *fout, void *ct
 
   if (enable_limits_min_B || enable_limits_max_B)
   {
-    // Set a minimum cell size on the edges
-    // Assume that at inflection points, Theta = theta. This should be true
+    // Set a minimum cell size on the edges.
+    // Theta_left/Theta_right are the physical (non-uniform) locations of the
+    // extrema bracketing this dB-accumulation region. theta lives in a
+    // different (uniform) coordinate, and the region's own span in that
+    // coordinate, [theta_bound_lower, theta_bound_upper], is generally NOT
+    // the same width as [Theta_left, Theta_right] -- regions accumulate
+    // equal dB, not equal theta or equal Theta. Anchoring the straight-line
+    // caps directly on raw theta (assuming theta ~= Theta_left/Theta_right)
+    // is only valid right at the region boundary; pivot on theta_bound_lower/
+    // upper instead so the cap is evaluated in the same coordinate as theta
+    // everywhere in the region (this matters most when a caller, e.g. the
+    // Gaussian smoothing quadrature, evaluates theta values whose own region
+    // is much narrower or wider in Theta-space than in theta-space).
     double Theta_left  = interval_lower;
     double Theta_right = interval_upper;
-    double theta_middle = 0.5 * (interval_lower + interval_upper);
+    double dB_this_region = fabs(gpm->constB_ctx->bmag_extrema[region+1] - gpm->constB_ctx->bmag_extrema[region]);
+    double theta_bound_lower = theta_lo + (dB_global_lower / dB_cell) * theta_dxi;
+    double theta_bound_upper = theta_lo + ((dB_global_lower + dB_this_region) / dB_cell) * theta_dxi;
+    double theta_middle = 0.5 * (theta_bound_lower + theta_bound_upper);
 
     bool left_is_maximum = gpm->constB_ctx->min_or_max[region];
     bool right_is_maximum = gpm->constB_ctx->min_or_max[region+1];
@@ -695,29 +709,29 @@ position_map_constB_z_numeric(double t, const double *xn, double *fout, void *ct
 
     double right_straight_line_value, left_straight_line_value;
     if (left_is_maximum){
-      left_straight_line_value = max_slope_max_B * theta + (1-max_slope_max_B) * Theta_left;
+      left_straight_line_value = Theta_left + max_slope_max_B * (theta - theta_bound_lower);
     }
     else {
-      left_straight_line_value = max_slope_min_B * theta + (1-max_slope_min_B) * Theta_left;
+      left_straight_line_value = Theta_left + max_slope_min_B * (theta - theta_bound_lower);
     }
 
     if (right_is_maximum){
-      right_straight_line_value = max_slope_max_B * theta + (1-max_slope_max_B) * Theta_right;
+      right_straight_line_value = Theta_right + max_slope_max_B * (theta - theta_bound_upper);
     }
     else {
-      right_straight_line_value = max_slope_min_B * theta + (1-max_slope_min_B) * Theta_right;
+      right_straight_line_value = Theta_right + max_slope_min_B * (theta - theta_bound_upper);
     }
 
-    if ( fout[0] < right_straight_line_value && 
-      ((right_is_maximum && enable_limits_max_B) || 
-      ((!right_is_maximum) && enable_limits_min_B))) 
+    if ( fout[0] < right_straight_line_value &&
+      ((right_is_maximum && enable_limits_max_B) ||
+      ((!right_is_maximum) && enable_limits_min_B)))
     {
       fout[0] = right_straight_line_value;
     }
 
-    if (fout[0] > left_straight_line_value && 
+    if (fout[0] > left_straight_line_value &&
       ((left_is_maximum && enable_limits_max_B) ||
-      ((!left_is_maximum) && enable_limits_min_B))) 
+      ((!left_is_maximum) && enable_limits_min_B)))
     {
       fout[0] = left_straight_line_value;
     }


### PR DESCRIPTION
Claude found an inconsistency in how the non-uniform position map is constructed for the Delta B minimizing map. The cap is fixed to pivot on the region's own uniform-coordinate bounds instead of raw theta, eliminating the geometry-breaking discontinuity and making maximum_slope_at_max_B safe to enable.

The slope limiters work by asking if the map is above or below the line that passes through the inflection point of the B field, the point where the non-uniform map changes from concave down to concave up, is above or below this line. The line has a slope set by the input file, so a linear map here is the maximum/minimum allowable deformation while preserving the map structure.

<img width="1426" height="813" alt="image" src="https://github.com/user-attachments/assets/827ed1b8-1432-4497-b9bb-ad3c77e6fd21" />

In this image, the y-axis is the new non-uniform position and the x-axis is the uniform axis. Here, the left side would have very sparse points, so we draw a red line with a known slope and instead use the blue region, where point density is lowest. Similarly, the grid gets very compact on the right, so we draw a line and take the blue linear part to keep the grid from getting too compact.