### PR TITLE
Fix GK scaled neutrals restart

### DIFF
--- a/gyrokinetic/apps/gk_neut_species_fluid.c
+++ b/gyrokinetic/apps/gk_neut_species_fluid.c
@@ -308,7 +308,9 @@ gk_neut_species_fluid_init(struct gkyl_gk *gk, struct gkyl_gyrokinetic_app *app,
   }
 
   // Initialize projection routine for initial conditions.
-  gk_neut_species_projection_init(app, ns, ns->info.projection, &ns->proj_init);
+  if (ns->info.init_from_file.type == 0) {
+    gk_neut_species_projection_init(app, ns, ns->info.projection, &ns->proj_init);
+  }
 
   // Allocate objects for computing diagnostic moments.
   int ndm = ns->info.num_diag_moments;

--- a/gyrokinetic/apps/gk_neut_species_projection.c
+++ b/gyrokinetic/apps/gk_neut_species_projection.c
@@ -176,27 +176,27 @@ gk_neut_species_projection_fluid_calc(gkyl_gyrokinetic_app *app, struct gk_neut_
     gkyl_proj_on_basis_advance(proj->proj_temp, tm, &app->local, proj->vtsq);
 
     // f[0] = mass*dens
-    gkyl_array_set_offset_range(s->f_host, s->info.mass, proj->dens, 0, &app->local);
+    gkyl_array_set_offset_range(proj->proj_host, s->info.mass, proj->dens, 0, &app->local);
 
     // f[1] = f[0]*udrift[0]
     // f[2] = f[0]*udrift[1]
     // f[3] = f[0]*udrift[2]
     for (int d=0; d<3; d++) {
-      gkyl_dg_mul_op_range(&app->basis, d+1, s->f_host, 0, s->f_host, d, proj->udrift, &app->local);
+      gkyl_dg_mul_op_range(&app->basis, d+1, proj->proj_host, 0, proj->proj_host, d, proj->udrift, &app->local);
     }
 
     // f[4] = 0.5*rho*u^2 + p/(gas_gamma-1)
     //      = 0.5*(rho*ux^2+rho*uy^2+rho*uz^2) + dens*temp/(gas_gamma-1)
     //      = 0.5*(f[1].udrift[0]+f[2].udrift[1]+f[3].udrift[2]) + dens*temp/(gas_gamma-1)
     gkyl_dg_mul_op_range(&app->basis, 0, proj->vtsq, 0, proj->dens, 0, proj->vtsq, &app->local);
-    gkyl_array_set_offset_range(s->f_host, 1.0/(s->info.gas_gamma-1.0), proj->vtsq, 4*app->basis.num_basis, &app->local);
+    gkyl_array_set_offset_range(proj->proj_host, 1.0/(s->info.gas_gamma-1.0), proj->vtsq, 4*app->basis.num_basis, &app->local);
     for (int d=0; d<3; d++) {
-      gkyl_dg_mul_op_range(&app->basis, 0, proj->dens, d+1, s->f_host, d, proj->udrift, &app->local);
-      gkyl_array_accumulate_offset_range(s->f_host, 0.5, proj->dens, 4*app->basis.num_basis, &app->local);
+      gkyl_dg_mul_op_range(&app->basis, 0, proj->dens, d+1, proj->proj_host, d, proj->udrift, &app->local);
+      gkyl_array_accumulate_offset_range(proj->proj_host, 0.5, proj->dens, 4*app->basis.num_basis, &app->local);
     }
 
     // Copy the contents into the array we will use (potentially on GPUs).
-    gkyl_array_copy(f, s->f_host);
+    gkyl_array_copy(f, proj->proj_host);
 
     // Multiply moments by the conf-space Jacobian.
     for (int d=0; d<s->num_moments; d++) {
@@ -219,6 +219,7 @@ gk_neut_species_projection_fluid_release(const struct gkyl_gyrokinetic_app *app,
     gkyl_array_release(proj->dens);
     gkyl_array_release(proj->udrift); 
     gkyl_array_release(proj->vtsq);
+    gkyl_array_release(proj->proj_host);
 
     gkyl_proj_on_basis_release(proj->proj_dens);
     gkyl_proj_on_basis_release(proj->proj_udrift);
@@ -227,37 +228,38 @@ gk_neut_species_projection_fluid_release(const struct gkyl_gyrokinetic_app *app,
 }
 
 static void 
-gk_neut_species_projection_fluid_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_species *s, 
+gk_neut_species_projection_fluid_init(struct gkyl_gyrokinetic_app *app, struct gk_neut_species *ns, 
   struct gkyl_gyrokinetic_projection inp, struct gk_proj *proj)
 {
   proj->proj_id = inp.proj_id;
   if (proj->proj_id == GKYL_PROJ_FUNC) {
     proj->proj_func = gkyl_proj_on_basis_inew( &(struct gkyl_proj_on_basis_inp) {
-        .grid = &s->grid,
-        .basis = &s->basis,
+        .grid = &ns->grid,
+        .basis = &ns->basis,
         .qtype = GKYL_GAUSS_QUAD,
-        .num_quad = s->basis.poly_order+1,
-        .num_ret_vals = s->num_moments,
+        .num_quad = ns->basis.poly_order+1,
+        .num_ret_vals = ns->num_moments,
         .eval = inp.func,
         .ctx = inp.ctx_func,
       }
     );
     if (app->use_gpu) {
-      proj->proj_host = mkarr(false, s->num_moments*s->basis.num_basis, s->local_ext.volume);
+      proj->proj_host = mkarr(false, ns->num_moments*ns->basis.num_basis, ns->local_ext.volume);
     }
   }
   else if (proj->proj_id == GKYL_PROJ_MAXWELLIAN_PRIM) {
-    int udim = s->num_moments-2;
+    int udim = ns->num_moments-2;
     proj->dens = mkarr(false, app->basis.num_basis, app->local_ext.volume);
     proj->udrift = mkarr(false, udim*app->basis.num_basis, app->local_ext.volume);
     proj->vtsq = mkarr(false, app->basis.num_basis, app->local_ext.volume);
+    proj->proj_host = mkarr(false, ns->f->ncomp, ns->f->size);
 
     proj->proj_dens = gkyl_proj_on_basis_new(&app->grid, &app->basis,
-      s->basis.poly_order+1, 1, inp.density, inp.ctx_density);
+      ns->basis.poly_order+1, 1, inp.density, inp.ctx_density);
     proj->proj_udrift = gkyl_proj_on_basis_new(&app->grid, &app->basis,
-      s->basis.poly_order+1, udim, inp.udrift, inp.ctx_udrift);
+      ns->basis.poly_order+1, udim, inp.udrift, inp.ctx_udrift);
     proj->proj_temp = gkyl_proj_on_basis_new(&app->grid, &app->basis,
-      s->basis.poly_order+1, 1, inp.temp, inp.ctx_temp);
+      ns->basis.poly_order+1, 1, inp.temp, inp.ctx_temp);
   }
 
   proj->neut_calc_func = gk_neut_species_projection_fluid_calc;

--- a/gyrokinetic/apps/gk_neut_species_scaling.c
+++ b/gyrokinetic/apps/gk_neut_species_scaling.c
@@ -258,8 +258,14 @@ gk_neut_species_scaling_apply_ic_cross(struct gkyl_gyrokinetic_app *app, struct 
   struct gk_scaling *sca)
 {
   if (sca->type == GKYL_GK_SPECIES_SCALING_RECYCLING_IZ_BALANCE) {
-    // Store the initial particle number density.
-    gkyl_array_set_offset(sca->Jm0_init, 1.0/ns->info.mass, ns->f, 0);
+    // Project and store the initial state. Need to re-project so that restarts use this as the state at t=0.
+    if (ns->info.init_from_file.type == 0)
+      gk_neut_species_projection_calc(app, ns, &ns->proj_init, ns->f1, 0.0);
+
+    gkyl_array_set_offset(sca->Jm0_init, 1.0/ns->info.mass, ns->f1, 0);
+
+    if (ns->info.init_from_file.type == 0)
+      gkyl_array_clear(ns->f1, 0.0);
   }
 }
 

--- a/gyrokinetic/apps/gyrokinetic.c
+++ b/gyrokinetic/apps/gyrokinetic.c
@@ -3349,10 +3349,10 @@ gkyl_gyrokinetic_app_from_file_neut_species(gkyl_gyrokinetic_app *app, int sidx,
   struct gk_neut_species *gk_ns = &app->neut_species[sidx];
   
   if (rstat.io_status == GKYL_ARRAY_RIO_SUCCESS) {
-    rstat.io_status =
-      gkyl_comm_array_read(gk_ns->comm, &gk_ns->grid, &gk_ns->local, gk_ns->f_host, fname);
+    rstat.io_status = gkyl_comm_array_read(gk_ns->comm, &gk_ns->grid, &gk_ns->local, gk_ns->f_host, fname);
     if (app->use_gpu)
       gkyl_array_copy(gk_ns->f, gk_ns->f_host);
+
     if (rstat.io_status == GKYL_ARRAY_RIO_SUCCESS) {
       gk_neut_species_source_calc(app, gk_ns, &gk_ns->src, gk_ns->lte.f_lte, 0.0);
       // Read volume and time integrated boundary flux diagnostics.


### PR DESCRIPTION
Previously when restarting it interpreted the frame we restart from as the t=0 state. Instead we need to re-project the initial conditions and record the true t=0 state. Also, need to use proj_host for this so that calling the projection doesn't interfere with the state read in from the restart frame.