### PR TITLE
Fix a memory leak in GK app

### DIFF
--- a/gyrokinetic/apps/gyrokinetic.c
+++ b/gyrokinetic/apps/gyrokinetic.c
@@ -155,6 +155,7 @@ gyrokinetic_deflate_delta_ts(struct gkyl_gyrokinetic_app* app, struct gkyl_array
   gkyl_translate_dim_release(transd_2d_1d);
   gkyl_array_release(buffer_perp);
   gkyl_array_copy(app->delta_ts_x_up, delta_ts_x_dev);
+  gkyl_array_release(delta_ts_x_dev);
 }
 
 gkyl_gyrokinetic_app*


### PR DESCRIPTION
`delta_ts_x_dev` was never released, idk how this went unnoticed, it popped out with compute sanitizer on Perlmutter GPU.