### PR TITLE
Fix PKPM SSP-RK3 stage-1 field limiter target

### DIFF
--- a/pkpm/apps/pkpm_update_explicit_ssp_rk3.c
+++ b/pkpm/apps/pkpm_update_explicit_ssp_rk3.c
@@ -38,7 +38,7 @@ pkpm_update_explicit_ssp_rk3(gkyl_pkpm_app* app, double dt0)
           for (int i=0; i<ns; ++i) {
             pkpm_fluid_species_limiter(app, &app->species[i], fout[i], fluidout[i]);
           }
-          pkpm_field_limiter(app, app->field, app->field->emnew);
+          pkpm_field_limiter(app, app->field, app->field->em1);
 
           dt = st.dt_actual;
           state = RK_STAGE_2;


### PR DESCRIPTION
The first PKPM SSP-RK3 stage writes its field result to `em1`, but the optional field limiter was called on `emnew`. With `field.limit_em = true`, stage 2 therefore consumed the un-limited `em1`.

This changes the stage-1 limiter target to `em1`, matching the stage output and the corresponding Vlasov SSP-RK3 implementation.

Validation:
- `make -j8 pkpm`
- focused driver harness: before the fix, the first limiter targets `emnew` and stage 2 receives the un-limited value 4; after the fix, the limiter targets `em1` and stage 2 receives the limited value 1
- actual Maxwell limiter kernel reduces the test Ex slope from 4 to 0 while retaining its average of 1
