### PR TITLE
Correcting outdated helical mapping in li_react creg tests.

### DIFF
--- a/gyrokinetic/creg/rt_gk_li_react_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_li_react_3x2v_p1.c
@@ -822,17 +822,8 @@ mapc2p(double t, const double* GKYL_RESTRICT zc, double* GKYL_RESTRICT xp, void*
   struct li_react_ctx *app = ctx;
   double x = zc[0], y = zc[1], z = zc[2];
 
-  double R0 = app->R0;
-  double a0 = app->a0;
-
-  double R = x;
-  double phi = z / (R0 + a0);
-  double X = R * cos(phi);
-  double Y = R * sin(phi);
-  double Z = y;
-
   // Set physical coordinates (X, Y, Z) from computational coordinates (x, y, z).
-  xp[0] = X; xp[1] = Y; xp[2] = Z;
+  xp[0] = x; xp[1] = y; xp[2] = z;
 }
 
 void
@@ -842,13 +833,12 @@ bfield_func(double t, const double* GKYL_RESTRICT zc, double* GKYL_RESTRICT fout
   double x = zc[0];
 
   double B0 = app->B0;
-  double R = app->R;
 
   // zc are computational coords. 
   // Set Cartesian components of magnetic field.
   fout[0] = 0.0;
   fout[1] = 0.0;
-  fout[2] = B0 * R / x;
+  fout[2] = B0;
 }
 
 int

--- a/gyrokinetic/creg/rt_gk_li_react_nonuniformv_3x2v_p1.c
+++ b/gyrokinetic/creg/rt_gk_li_react_nonuniformv_3x2v_p1.c
@@ -822,17 +822,8 @@ mapc2p(double t, const double* GKYL_RESTRICT zc, double* GKYL_RESTRICT xp, void*
   struct li_react_ctx *app = ctx;
   double x = zc[0], y = zc[1], z = zc[2];
 
-  double R0 = app->R0;
-  double a0 = app->a0;
-
-  double R = x;
-  double phi = z / (R0 + a0);
-  double X = R * cos(phi);
-  double Y = R * sin(phi);
-  double Z = y;
-
   // Set physical coordinates (X, Y, Z) from computational coordinates (x, y, z).
-  xp[0] = X; xp[1] = Y; xp[2] = Z;
+  xp[0] = x; xp[1] = y; xp[2] = z;
 }
 
 void
@@ -842,13 +833,12 @@ bfield_func(double t, const double* GKYL_RESTRICT zc, double* GKYL_RESTRICT fout
   double x = zc[0];
 
   double B0 = app->B0;
-  double R = app->R;
 
   // zc are computational coords. 
   // Set Cartesian components of magnetic field.
   fout[0] = 0.0;
   fout[1] = 0.0;
-  fout[2] = B0 * R / x;
+  fout[2] = B0;
 }
 
 static inline void


### PR DESCRIPTION
Changing helical mapping to Cartesian since geometry is not important for these multi-Z impurity tests. This avoids the orthogonality and handedness check errors.